### PR TITLE
delete CNAME

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-schoolidforge.tk


### PR DESCRIPTION
this file points to the url of the original project and is therefore unnecessary rn. Removing just makes it neater and stuff